### PR TITLE
Feat: Implementation of the Crawler Configuration and Prompting

### DIFF
--- a/src/main/java/org/crawler/config/Configuration.java
+++ b/src/main/java/org/crawler/config/Configuration.java
@@ -1,5 +1,9 @@
 package org.crawler.config;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public class Configuration {
 
     private String url;
@@ -13,6 +17,36 @@ public class Configuration {
         this.domains = domains;
         this.targetLanguage = targetLanguage;
     }
+
+    public static Configuration requestConfiguration () {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+
+        try {
+            System.out.println("Please enter the URL you want to crawl: ");
+            String url = reader.readLine();
+
+            System.out.println("Please enter the maximum depth you want to crawl (max. 2): ");
+            int maxDepth = Math.max(Integer.parseInt(reader.readLine()), 2);
+
+            System.out.println("Please enter the domains you want to crawl: ");
+            System.out.println("Separate multiple domains with a comma (,)");
+            System.out.println("To allow all domains, leave the field empty");
+            System.out.println("Example: google.com, orf.at");
+
+            String[] domains = reader.readLine().trim().split(",");
+
+            System.out.println("Please enter the language you want to crawl: ");
+            System.out.println("Example: en, de");
+            String language = reader.readLine();
+
+
+            return new Configuration(url, maxDepth, domains, language);
+        } catch (IOException e) {
+            System.out.println("Error while reading input. Please try again.");
+            return requestConfiguration();
+        }
+    }
+
 
     public String getUrl () {
         return url;

--- a/src/main/java/org/crawler/config/Configuration.java
+++ b/src/main/java/org/crawler/config/Configuration.java
@@ -1,0 +1,28 @@
+package org.crawler.config;
+
+public class Configuration {
+
+    private String url;
+    private int maxDepth;
+    private String[] domains;
+    private String targetLanguage;
+
+    public Configuration (String url, int maxDepth, String[] domains, String targetLanguage) {
+        this.url = url;
+        this.maxDepth = maxDepth;
+        this.domains = domains;
+        this.targetLanguage = targetLanguage;
+    }
+
+    public String getUrl () {
+        return url;
+    }
+
+    public int getMaxDepth () {
+        return maxDepth;
+    }
+
+    public String[] getDomains () {
+        return domains;
+    }
+}

--- a/src/test/java/config/ConfigurationTests.java
+++ b/src/test/java/config/ConfigurationTests.java
@@ -1,0 +1,13 @@
+package config;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTests {
+
+    @Test
+    public void testRequestConfiguration () {
+        //* Mocking the JAVA IO Classes (BufferedReader) to test the requestConfiguration method
+        //* does not provide any useful information about the method's functionality
+    }
+
+}


### PR DESCRIPTION
The following changes were made in this Pull request:
- created a new `Configuration` class that certain private fields necessary for the future Crawling. 
- created the `requestConfiguration` functionality, which prompts the user for the crawler-configuration
- drafted test-case for the configuration prompt, however testing the IO classes provided by java is redundant