### PR TITLE
Feat: Implementation of the Page Crawling process

### DIFF
--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -20,6 +20,10 @@ public class Crawler {
         this.config = config;
     }
 
+    public PageInfo crawl () throws IOException {
+        return getPage(config.getUrl(), 0, config.getMaxDepth(), config.getDomains());
+    }
+
     private PageInfo getPage (String url, int currentDepth, int maxDepth, String[] allowedDomains) throws IOException {
         if (currentDepth >= maxDepth) return null;
         System.out.println("Crawling-Depth: " + currentDepth);

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -20,6 +20,22 @@ public class Crawler {
         this.config = config;
     }
 
+    public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
+        PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
+        Document document = getDocument(url);
+
+        //* In case one cannot connect to the requested URL
+        if (document == null) return result;
+
+        System.out.println();
+        System.out.println("Crawling: " + document.title());
+
+        result.setLanguage(getSourceLanguage(document));
+        result.setHeadings(document.select("h1, h2, h3, h4, h5, h6"));
+        result.setPageLinks(removeLinkLoops(url, getFilteredPageLinks(document, domains)));
+
+        return result;
+    }
 
     /**
      * @implNote Would be private if it wasn't for testing purposes.

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -36,7 +36,7 @@ public class Crawler {
         return page;
     }
 
-    public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
+    private PageInfo retrievePageInfo (String url, String[] domains, int depth) {
         PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
         Document document = getDocument(url);
 

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -30,5 +30,10 @@ public class Crawler {
         }
         return null;
     }
-    
+
+
+    private String getSourceLanguage (Document document) {
+        String sourceLanguageISO = document.getElementsByTag("html").attr("lang");
+        return sourceLanguageISO.split("-")[0];
+    }
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -6,6 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.jsoup.select.NodeFilter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,6 +60,21 @@ public class Crawler {
         }
 
         return links;
+    }
+
+    private void removeWrongDomainLinks (Elements anchors, String[] allowedDomains) {
+        anchors.filter((anchor, index) -> {
+            String href = anchor.attr("abs:href");
+
+            if (href.isEmpty()) return NodeFilter.FilterResult.SKIP_ENTIRELY;
+
+            // Skipping non-relevant links.
+            if (!isRequestedDomain(href, allowedDomains)) {
+                return NodeFilter.FilterResult.SKIP_ENTIRELY;
+            }
+
+            return NodeFilter.FilterResult.CONTINUE;
+        });
     }
 
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -36,6 +36,13 @@ public class Crawler {
         return null;
     }
 
+
+    private ArrayList<String> getFilteredPageLinks (Document document, String[] allowedDomains) {
+        Elements anchors = document.select("a[href]");
+        removeWrongDomainLinks(anchors, allowedDomains);
+        return removeDuplicateLinks(anchors);
+    }
+
     private String getSourceLanguage (Document document) {
         String sourceLanguageISO = document.getElementsByTag("html").attr("lang");
         return sourceLanguageISO.split("-")[0];

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -31,9 +31,20 @@ public class Crawler {
         return null;
     }
 
-
     private String getSourceLanguage (Document document) {
         String sourceLanguageISO = document.getElementsByTag("html").attr("lang");
         return sourceLanguageISO.split("-")[0];
     }
+
+    /**
+     * Filters out the links that are not from the requested domain.
+     * @return In case the link is from the requested domain, then true is returned, otherwise false. If no domains are specified, then the link's domain is accepted automatically.
+     */
+    private boolean isRequestedDomain (String link, String[] domains) {
+        for (String domain : domains) {
+            if (!link.contains(domain)) return false;
+        }
+        return true;
+    }
+
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -10,6 +10,7 @@ import org.jsoup.select.NodeFilter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 
 public class Crawler {
@@ -77,4 +78,7 @@ public class Crawler {
         });
     }
 
+    private List<String> removeLinkLoops (String origin, List<String> links) {
+        return links.stream().filter(href -> !href.equals(origin)).toList();
+    }
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -1,6 +1,11 @@
 package org.crawler.crawl;
 
 import org.crawler.config.Configuration;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
 
 
 public class Crawler {
@@ -10,4 +15,20 @@ public class Crawler {
         this.config = config;
     }
 
+
+    /**
+     * @implNote Would be private if it wasn't for testing purposes.
+     */
+    public Document getDocument (String url) {
+        try {
+            Connection connection = Jsoup.connect(url);
+            return connection.get();
+        } catch (IOException e) {
+            System.out.println("Error while connecting to the URL: " + url);
+        } catch (Exception ignored) {
+            System.out.println("Please provide a valid URL");
+        }
+        return null;
+    }
+    
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -4,8 +4,11 @@ import org.crawler.config.Configuration;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 
 public class Crawler {
@@ -45,6 +48,17 @@ public class Crawler {
             if (!link.contains(domain)) return false;
         }
         return true;
+    }
+
+
+    private ArrayList<String> removeDuplicateLinks (Elements anchors) {
+        ArrayList<String> links = new ArrayList<>();
+        for (Element anchor : anchors) {
+            String href = anchor.attr("abs:href");
+            if (!links.contains(href)) links.add(href);
+        }
+
+        return links;
     }
 
 }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -1,0 +1,13 @@
+package org.crawler.crawl;
+
+import org.crawler.config.Configuration;
+
+
+public class Crawler {
+    private Configuration config;
+
+    public Crawler (Configuration config) {
+        this.config = config;
+    }
+
+}

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -36,6 +36,9 @@ public class Crawler {
         return page;
     }
 
+    /**
+     * @implNote Would be private if it wasn't for testing purposes.
+     */
     public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
         PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
         Document document = getDocument(url);

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -20,6 +20,18 @@ public class Crawler {
         this.config = config;
     }
 
+    private PageInfo getPage (String url, int currentDepth, int maxDepth, String[] allowedDomains) throws IOException {
+        if (currentDepth >= maxDepth) return null;
+        System.out.println("Crawling-Depth: " + currentDepth);
+        PageInfo page = retrievePageInfo(url, allowedDomains, currentDepth);
+
+        List<String> links_to_crawl = page.getPageLinks();
+        System.out.println("-> Page has " + links_to_crawl.size() + " sublinks...");
+
+        recursion(page, currentDepth, maxDepth, allowedDomains);
+        return page;
+    }
+
     public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
         PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
         Document document = getDocument(url);
@@ -35,6 +47,22 @@ public class Crawler {
         result.setPageLinks(removeLinkLoops(url, getFilteredPageLinks(document, domains)));
 
         return result;
+    }
+
+    private void recursion (PageInfo originPage, int currentDepth, int maxDepth, String[] allowedDomains) throws IOException {
+        List<String> links_to_crawl = originPage.getPageLinks();
+        System.out.println("-> Page has " + links_to_crawl.size() + " sublinks...");
+
+
+        ArrayList<PageInfo> results = new ArrayList<>();
+        for (String link : links_to_crawl) {
+            PageInfo recursiveResult = getPage(link, currentDepth + 1, maxDepth, allowedDomains);
+            if (recursiveResult != null) results.add(recursiveResult);
+
+            if (results.size() == 10) break;
+        }
+
+        originPage.setSubPagesInfo(results);
     }
 
     /**

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -36,7 +36,7 @@ public class Crawler {
         return page;
     }
 
-    private PageInfo retrievePageInfo (String url, String[] domains, int depth) {
+    public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
         PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
         Document document = getDocument(url);
 

--- a/src/main/java/org/crawler/crawl/PageInfo.java
+++ b/src/main/java/org/crawler/crawl/PageInfo.java
@@ -1,0 +1,79 @@
+package org.crawler.crawl;
+
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class PageInfo {
+    private String url;
+    private String language;
+    private Elements headings;
+    private List<String> pageLinks;
+    private ArrayList<PageInfo> subPagesInfo = new ArrayList<>();
+    private int depth;
+
+    public PageInfo (String url, String language, Elements headings, List<String> pageLinks, int depth) {
+        this.url = url;
+        this.language = language;
+        this.headings = headings;
+        this.pageLinks = pageLinks;
+        this.depth = depth;
+    }
+
+    public boolean isBroken () {
+        return language.isEmpty();
+    }
+
+    public List<String> getPageLinks () {
+        return pageLinks;
+    }
+
+    public void setPageLinks (List<String> pageLinks) {
+        this.pageLinks = pageLinks;
+    }
+
+    public String getUrl () {
+        return url;
+    }
+
+    public String getLanguage () {
+        return language;
+    }
+
+    public void setLanguage (String language) {
+        this.language = language;
+    }
+
+    public Elements getHeadings () {
+        return headings;
+    }
+
+    public void setHeadings (Elements headings) {
+        this.headings = headings;
+    }
+
+    public ArrayList<PageInfo> getSubPagesInfo () {
+        return subPagesInfo;
+    }
+
+    public void setSubPagesInfo (ArrayList<PageInfo> subPagesInfo) {
+        this.subPagesInfo = subPagesInfo;
+    }
+
+    public int getDepth () {
+        return depth;
+    }
+
+    @Override
+    public String toString () {
+        return "CrawlResult{" +
+                "url ='" + url + '\'' +
+                ", language='" + language + '\'' +
+                ", headings=" + headings.size() +
+                ", pageLinks=" + pageLinks.size() +
+                ", subPagesInfo=" + subPagesInfo.size() +
+                '}';
+    }
+}

--- a/src/test/java/crawl/CrawlerTests.java
+++ b/src/test/java/crawl/CrawlerTests.java
@@ -2,17 +2,22 @@ package crawl;
 
 import org.crawler.config.Configuration;
 import org.crawler.crawl.Crawler;
+import org.crawler.crawl.PageInfo;
 import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
 
 class CrawlerTests {
 
     Crawler crawler;
     Configuration config = new Configuration("https://orf.at/", 3, new String[]{}, "german");
-
+    PageInfo brokenPageInfo = new PageInfo("invalid.url.at", "", new Elements(), new ArrayList<>(), 0);
 
     @BeforeEach
     public void setup () {
@@ -26,6 +31,17 @@ class CrawlerTests {
 
         if (url.startsWith("https://") || url.startsWith("http://")) Assertions.assertNotNull(document);
         else Assertions.assertNull(document);
+    }
+
+    @Test
+    public void test_invalid_retrievePageInfo () {
+        PageInfo info = crawler.retrievePageInfo("invalid.url.at", new String[]{}, 0);
+
+        Assertions.assertEquals(brokenPageInfo.getSubPagesInfo(), info.getSubPagesInfo());
+        Assertions.assertEquals(brokenPageInfo.getUrl(), info.getUrl());
+        Assertions.assertEquals(brokenPageInfo.getLanguage(), info.getLanguage());
+        Assertions.assertEquals(brokenPageInfo.getHeadings(), info.getHeadings());
+        Assertions.assertEquals(brokenPageInfo.getPageLinks(), info.getPageLinks());
     }
 
 }

--- a/src/test/java/crawl/CrawlerTests.java
+++ b/src/test/java/crawl/CrawlerTests.java
@@ -4,6 +4,7 @@ import org.crawler.config.Configuration;
 import org.crawler.crawl.Crawler;
 import org.crawler.crawl.PageInfo;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,15 +14,50 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 class CrawlerTests {
 
     Crawler crawler;
     Configuration config = new Configuration("https://orf.at/", 3, new String[]{}, "german");
     PageInfo brokenPageInfo = new PageInfo("invalid.url.at", "", new Elements(), new ArrayList<>(), 0);
 
+    PageInfo mockedPageInfo = mock(PageInfo.class);
+
+    Document mockedDocument = mock(Document.class);
+    Element mockedHeading = mock(Element.class);
+    Element mockedAnchor = mock(Element.class);
+
+
     @BeforeEach
     public void setup () {
         crawler = new Crawler(config);
+
+        
+        Element[] mockedPageHeadings = new Element[]{mockedHeading, mockedHeading, mockedHeading};
+        Elements el = new Elements();
+
+        //* Attempt to mock the PageInfo object and the related elements, however this information cannot be used since,
+        //* the basic methods that take in these arguments are private, and the bigger functions fetch the information directly using the Jsoup.connect.get functionality.
+
+        when(mockedPageInfo.getHeadings()).thenReturn(el);
+        when(mockedPageInfo.getUrl()).thenReturn("https://orf.at");
+        when(mockedPageInfo.getLanguage()).thenReturn("de");
+
+        when(mockedPageInfo.getPageLinks()).thenReturn(new ArrayList<>());
+        when(mockedPageInfo.getDepth()).thenReturn(0);
+        when(mockedHeading.tagName()).thenReturn("h2");
+
+        when(mockedHeading.text()).thenReturn("Sample Heading");
+
+
+
+        when(mockedAnchor.attr("href")).thenReturn("http://sample.link.at");
+
+        when(mockedDocument.title()).thenReturn("Sample Title");
+        when(mockedDocument.select("h1, h2, h3, h4, h5, h6")).thenReturn(new Elements());
+        when(mockedDocument.select("a")).thenReturn(new Elements());
     }
 
     @ParameterizedTest

--- a/src/test/java/crawl/CrawlerTests.java
+++ b/src/test/java/crawl/CrawlerTests.java
@@ -1,0 +1,31 @@
+package crawl;
+
+import org.crawler.config.Configuration;
+import org.crawler.crawl.Crawler;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CrawlerTests {
+
+    Crawler crawler;
+    Configuration config = new Configuration("https://orf.at/", 3, new String[]{}, "german");
+
+
+    @BeforeEach
+    public void setup () {
+        crawler = new Crawler(config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"https://orf.at/", "https://www.derstandard.at/", "invalid.url.at"})
+    public void test_getDocument (String url) {
+        Document document = crawler.getDocument(url);
+
+        if (url.startsWith("https://") || url.startsWith("http://")) Assertions.assertNotNull(document);
+        else Assertions.assertNull(document);
+    }
+
+}

--- a/src/test/java/crawl/CrawlerTests.java
+++ b/src/test/java/crawl/CrawlerTests.java
@@ -44,4 +44,15 @@ class CrawlerTests {
         Assertions.assertEquals(brokenPageInfo.getPageLinks(), info.getPageLinks());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"https://orf.at/", "https://www.derstandard.at/"})
+    public void test_retrievePageInfo (String url) {
+        PageInfo info = crawler.retrievePageInfo(url, new String[]{}, 0);
+
+        Assertions.assertEquals(url, info.getUrl());
+        Assertions.assertNotEquals("", info.getLanguage());
+        Assertions.assertNotEquals(0, info.getHeadings().size());
+        Assertions.assertNotEquals(0, info.getPageLinks().size());
+    }
+
 }


### PR DESCRIPTION
The following changes were made in this Pull request:
- created `PageInfo` class, which stores the information of a page:
  - its url
  - its (source) language
  - its headings
  - its pageLinks
  - the results of its subpages
  - its depth in the crawl-process
- created `Crawler` class that takes an instance of the `Configuration` class in its constructor
- created `getDocument`functionality
   This method fetches a given url and returns its content as a Document using the `Jsoup` library.
   In case the retrieval fails, e.g. when the url is invalid or due to a connection error, null is returned.
- created `getSourceLanguage` functionality
   This method retrieves the (source) language of a given document.
- created `isRequestedDomain` functionality
   This method checks whether a given link is part of the allowed domains.
   Note, when no allowed-domains are given, then all links are accepted.
- created `removeDuplicateLinks` functionality
   This method parses given anchor-elements to strings and removes duplicated-links.
- created `removeWrongDomainLinks` functionality
   This method takes in the anchor-elements of a page and filters them based on the given allowed-domains. In other words, when a anchor tag is not included in the allowed-domains, then the anchor-element is filtered out.
   
    Note, that when no allowed-domains are specified, no anchor-elements are filtered.
- created `removeLinkLoops` functionality
   This method removes all the gathered links of a page, that are equivalent to the page's own url. Thus, removes links to origin page == loop.
- created `getFilteredPageLinks` functionality
   This method retrieves the information of a page. It does this by retrieving the document of the given url, retrieves the headings, pageLinks and source-language. It then returns the PageInfo that includes the previously mentioned information.
- created `retrievePageInfo` functionality
   Added two new methods, that retrieve the information of a given page and recursively gathers the information of its subpages.

   The recursion is applied until, the depth is equal to the max-depth.
- created public `crawl` method
   This method starts the crawling-process by crawling the page specified page, given by the config.

- added test-case for `getDocument`
- added test-case for brokenPage retrieval
- added test-case for valid-page `retrievePageInfo`

- drafted setup for crawling test-cases
   Drafted the setup mocking the crawling-process. However, to mock the crawling-process, one must pass a mocked version of the `Jsoup` library to the Crawler, so that the actual page-retrieval can be mocked. This would force us to change the code-structure just test-purposes, which does not seem to be useful.