### PR TITLE
refactor: Removed unnecessary Translation Test-Case

### DIFF
--- a/src/test/java/translate/TranslationTests.java
+++ b/src/test/java/translate/TranslationTests.java
@@ -11,17 +11,9 @@ public class TranslationTests {
     @Test
     public void testTranslate () throws IOException, InterruptedException {
         //! This test requires an API key to be set as an environment variable.
-        Assertions.assertNotNull(System.getenv().get("API_KEY"));
+        Assertions.assertNotNull(System.getenv().get("API_KEY"), "API_KEY not found. Please set the API-Key as an environment variable.");
 
         String translation = Translater.translate("Hello World", "de");
         Assertions.assertEquals("Hallo Welt", translation);
-    }
-
-    @Test
-    public void testTranslate_MissingKey () throws IOException, InterruptedException {
-        Assertions.assertNull(System.getenv().get("API_KEY"));
-
-        String translation = Translater.translate("Hello World", "de");
-        Assertions.assertEquals("Hello World (Not translated because of missing API-Key)", translation);
     }
 }


### PR DESCRIPTION
Removed test-case that testet whether the api-key is missing. Since it is not possible for the api key to exist and to be missing at the same time, this test-case has been removed.