### PR TITLE
Feat: Implemenation of Colored System Messages

### DIFF
--- a/src/main/java/org/crawler/Console/Color.java
+++ b/src/main/java/org/crawler/Console/Color.java
@@ -1,0 +1,63 @@
+package org.crawler.Console;
+
+/**
+ * Enum class that offers a variety of colors for the console output.
+ * Each color has then different variants like bold, underlined, bright, etc. that can be accessed using the enum's getters.
+ */
+public enum Color {
+    Black("\033[0;30m", "\033[1;30m", "\033[4;30m", "\033[40m", "\033[0;90m", "\033[1;90m", "\033[0;100m"),
+    Red("\033[0;31m", "\033[1;31m", "\033[4;31m", "\033[41m", "\033[0;91m", "\033[1;91m", "\033[0;101m"),
+    Green("\033[0;32m", "\033[1;32m", "\033[4;32m", "\033[42m", "\033[0;92m", "\033[1;92m", "\033[0;102m"),
+    Yellow("\033[0;33m", "\033[1;33m", "\033[4;33m", "\033[43m", "\033[0;93m", "\033[1;93m", "\033[0;103m"),
+    Blue("\033[0;34m", "\033[1;34m", "\033[4;34m", "\033[44m", "\033[0;94m", "\033[1;94m", "\033[0;104m"),
+    Purple("\033[0;35m", "\033[1;35m", "\033[4;35m", "\033[45m", "\033[0;95m", "\033[1;95m", "\033[0;105m"),
+    Cyan("\033[0;36m", "\033[1;36m", "\033[4;36m", "\033[46m", "\033[0;96m", "\033[1;96m", "\033[0;106m"),
+    White("\033[0;37m", "\033[1;37m", "\033[4;37m", "\033[47m", "\033[0;97m", "\033[1;97m", "\033[0;107m");
+
+    private final String regular;
+    private final String bold;
+    private final String underlined;
+    private final String background;
+    private final String bright;
+    private final String boldBright;
+    private final String backgroundBright;
+
+    Color (String regular, String bold, String underlined, String background,
+           String bright, String boldBright, String backgroundBright) {
+        this.regular = regular;
+        this.bold = bold;
+        this.underlined = underlined;
+        this.background = background;
+        this.bright = bright;
+        this.boldBright = boldBright;
+        this.backgroundBright = backgroundBright;
+    }
+
+    public String getRegular () {
+        return regular;
+    }
+
+    public String getBold () {
+        return bold;
+    }
+
+    public String getUnderlined () {
+        return underlined;
+    }
+
+    public String getBackground () {
+        return background;
+    }
+
+    public String getBright () {
+        return bright;
+    }
+
+    public String getBoldBright () {
+        return boldBright;
+    }
+
+    public String getBackgroundBright () {
+        return backgroundBright;
+    }
+}

--- a/src/main/java/org/crawler/Console/ColorType.java
+++ b/src/main/java/org/crawler/Console/ColorType.java
@@ -1,0 +1,8 @@
+package org.crawler.Console;
+
+/**
+ * Enum to define the variant for a given color.
+ */
+public enum ColorType {
+    regular, bold, underlined, background, bright, boldBright, backgroundBright
+}

--- a/src/main/java/org/crawler/Console/Colorizer.java
+++ b/src/main/java/org/crawler/Console/Colorizer.java
@@ -1,0 +1,47 @@
+package org.crawler.Console;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Colorizer {
+    public static final String RESET = "\033[0m";
+
+    private static final Map<String, Map<ColorType, String>> colorMap = new HashMap<>();
+
+    static {
+        for (Color color : Color.values()) {
+            Map<ColorType, String> colorMap = new HashMap<>();
+            colorMap.put(ColorType.regular, color.getRegular());
+            colorMap.put(ColorType.bold, color.getBold());
+            colorMap.put(ColorType.underlined, color.getUnderlined());
+            colorMap.put(ColorType.background, color.getBackground());
+            colorMap.put(ColorType.bright, color.getBright());
+            colorMap.put(ColorType.boldBright, color.getBoldBright());
+            colorMap.put(ColorType.backgroundBright, color.getBackgroundBright());
+            Colorizer.colorMap.put(color.name(), colorMap);
+        }
+    }
+
+    /**
+     * Method to simply colorize a message using a given color without any specific variants (regular).
+     * @param message the message to colorize
+     * @param color the color to use
+     * @return the colorized message
+     */
+    public static String colorize (String message, Color color) {
+        String colorCode = colorMap.get(color.name()).get(ColorType.regular);
+        return colorCode + message + RESET;
+    }
+
+    /**
+     * Method to colorize a message using a given color and a specific variant.
+     * @param message the message to colorize
+     * @param color the color to use
+     * @param type the variant to use
+     * @return the colorized message
+     */
+    public static String colorize (String message, Color color, ColorType type) {
+        String colorCode = colorMap.get(color.name()).get(type);
+        return colorCode + message + RESET;
+    }
+}

--- a/src/main/java/org/crawler/Console/Console.java
+++ b/src/main/java/org/crawler/Console/Console.java
@@ -1,0 +1,43 @@
+package org.crawler.Console;
+
+import static java.lang.String.format;
+import static org.crawler.Console.Color.Yellow;
+import static org.crawler.Console.ColorType.bright;
+import static org.crawler.Console.Colorizer.colorize;
+
+public class Console {
+    /**
+     * This method is used to get the caller's class name and line number.
+     * @return A string containing the caller's class name and line number.
+     */
+    private static String getCallerInfo () {
+        int traceOriginIndex = 3;
+        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+
+        String name = stackTraceElements[traceOriginIndex].getClassName().split("\\.")[stackTraceElements[traceOriginIndex].getClassName().split("\\.").length - 1];
+        return format("[%s::l %s]", name, stackTraceElements[traceOriginIndex].getLineNumber());
+    }
+
+    /**
+     * This method is used to print a message to the console, including the caller's class name and line number.
+     * @param message The message to be printed.
+     */
+    public static void print (String... message) {
+        String caller = getCallerInfo();
+        String merge = String.join(" ", message);
+
+        System.out.println(caller + ": " + merge);
+    }
+
+    /**
+     * This method is used to print a message to the console, including the caller's class name and line number, with a specified color.
+     * @param color The color that is applied to the message.
+     * @param message The message to be printed.
+     */
+    public static void print (Color color, String... message) {
+        String caller = getCallerInfo();
+        String merge = String.join(" ", message);
+
+        System.out.println(colorize(caller + ":", Yellow, bright) + " " + colorize(merge, color));
+    }
+}

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -1,5 +1,6 @@
 package org.crawler.crawl;
 
+import org.crawler.Console.Console;
 import org.crawler.config.Configuration;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
@@ -11,6 +12,8 @@ import org.jsoup.select.NodeFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.crawler.Console.Color.Red;
 
 
 public class Crawler {
@@ -80,9 +83,9 @@ public class Crawler {
             Connection connection = Jsoup.connect(url);
             return connection.get();
         } catch (IOException e) {
-            System.out.println("Error while connecting to the URL: " + url);
+            Console.print(Red, "Retrieval was not successful for", url, "due to an IOException.");
         } catch (Exception ignored) {
-            System.out.println("Please provide a valid URL");
+            Console.print(Red, "Retrieving document from", url, "failed.");
         }
         return null;
     }


### PR DESCRIPTION
The following changes are made in this Pull request:
- created `Color` enum
   This enum holds different colors where each color itself has further variants. With the help of this enum it is possible to select a specific color, e.g Black and then choose from its variants like regular, bold and others.
- created `ColorType` enum
   This enum is used to specify which variant of a selected color should be used, e.g. bold, underlined, etc.
- created `Colorizer` class
   This class exposes a `colorize` method, which has two signatures. The first signature takes in a message and a color. It then adds the color prefix before the message and color-reset value at the end. This way the message is colorized without any specific variant (default -> regular).
   
   The second signature has an additional argument, the ColorType. With the help of this argument it is possible to choose a specific variant of the request color, e.g. bold.
- created `Console` class
   This class exposes a `print` method that has two signatures. The first signature takes in a sequence of message arguments. In doing so it is somewhat similar to the String.format method, since the given message can be split into multiple arguments to use variables without having to escape them.
   
   The second signature takes in a color argument that is used to colorize the sequence of message arguments.
- replaced system-prints with Console.print in the `Crawler` class 
   Replaced system-prints in the error-handling section for the document-retrieval with the new Console.print method.