### PR TITLE
Feat: Implementation of Concurrent Crawling

### DIFF
--- a/src/main/java/org/crawler/Main.java
+++ b/src/main/java/org/crawler/Main.java
@@ -1,22 +1,29 @@
 package org.crawler;
 
+import org.crawler.Console.Color;
+import org.crawler.Console.Console;
 import org.crawler.config.Configuration;
-import org.crawler.crawl.Crawler;
+import org.crawler.crawl.ConcurrencyHandler;
 import org.crawler.crawl.PageInfo;
 
-import java.io.IOException;
+import java.util.List;
 
 public class Main {
-    public static void main (String[] args) throws IOException {
+    public static void main (String[] args) {
         if (!System.getenv().containsKey("API_KEY")) {
             System.out.println("Translation API-Key not found. Please set the API-Key as an environment variable.");
             return;
         }
 
         Configuration config = Configuration.requestConfiguration();
-        Crawler crawler = new Crawler(config);
-        PageInfo result = crawler.crawl();
-        Printer.printReport(Printer.createReport(result));
 
+        ConcurrencyHandler handler = new ConcurrencyHandler(config);
+        List<PageInfo> thread_results = handler.getResults();
+
+        System.out.println();
+        Console.print(Color.Green, "All Crawlers have finished, for these urls:");
+        thread_results.forEach(result -> System.out.println(result.getUrl()));
+
+        Printer.printReports(thread_results);
     }
 }

--- a/src/main/java/org/crawler/Printer.java
+++ b/src/main/java/org/crawler/Printer.java
@@ -1,5 +1,6 @@
 package org.crawler;
 
+import org.crawler.Console.Console;
 import org.crawler.crawl.PageInfo;
 import org.jsoup.nodes.Element;
 
@@ -7,7 +8,10 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import static org.crawler.Console.Color.Red;
 
 public class Printer {
     public static void printReport (List<String> lines) throws IOException {
@@ -31,6 +35,27 @@ public class Printer {
         lines.addAll(createSubPagesReport(page));
 
         return lines;
+    }
+
+    /**
+     * This method creates a report for multiple PageInfos.
+     * @param pageInfos A list of PageInfos for which a report shall be created.
+     */
+    public static void printReports (List<PageInfo> pageInfos) {
+        List<String> reportLines = new ArrayList<>();
+
+        for (PageInfo pageInfo : pageInfos) {
+            reportLines.addAll(createReport(pageInfo));
+
+            String[] spacings = new String[]{"", "", "", "", ""};
+            reportLines.addAll(Arrays.stream(spacings).toList());
+        }
+
+        try {
+            printReport(reportLines);
+        } catch (IOException e) {
+            Console.print(Red, "Creating single report for multiple PageInfos failed.");
+        }
     }
 
     private static List<String> formatPageHeadings (PageInfo page) {

--- a/src/main/java/org/crawler/Printer.java
+++ b/src/main/java/org/crawler/Printer.java
@@ -20,7 +20,7 @@ public class Printer {
         writer.close();
     }
 
-    public static List<String> createReport (PageInfo page) throws IOException {
+    public static List<String> createReport (PageInfo page) {
         List<String> lines = new ArrayList<>();
 
         lines.add(String.format("input: <%s>", page.getUrl()));
@@ -47,7 +47,7 @@ public class Printer {
         return headings;
     }
 
-    private static List<String> createSubPagesReport (PageInfo page) throws IOException {
+    private static List<String> createSubPagesReport (PageInfo page) {
         List<String> lines = new ArrayList<>();
 
         for (PageInfo subPage : page.getSubPagesInfo()) {
@@ -64,7 +64,8 @@ public class Printer {
 
         return Integer.parseInt(heading.tagName().split("h")[1]);
     }
-    private static String createHeading(int level, String title) {
+
+    private static String createHeading (int level, String title) {
         StringBuilder builder = new StringBuilder();
         builder.append("#".repeat(level));
         builder.append(" ");

--- a/src/main/java/org/crawler/config/Configuration.java
+++ b/src/main/java/org/crawler/config/Configuration.java
@@ -13,7 +13,7 @@ import static org.crawler.config.InputValidation.validate;
 
 public class Configuration {
 
-    private String url;
+    private String[] urls;
     private int maxDepth;
     private String[] domains;
 
@@ -21,8 +21,8 @@ public class Configuration {
     @SuppressWarnings("FieldCanBeLocal")
     private String targetLanguage;
 
-    public Configuration (String url, int maxDepth, String[] domains, String targetLanguage) {
-        this.url = url;
+    public Configuration (String[] urls, int maxDepth, String[] domains, String targetLanguage) {
+        this.urls = urls;
         this.maxDepth = maxDepth;
         this.domains = domains;
         this.targetLanguage = targetLanguage;
@@ -34,8 +34,10 @@ public class Configuration {
         try {
             System.out.println(Colorizer.colorize("Welcome to the Crawler-Configuration-Tool!", Green, bold));
 
-            System.out.print(Colorizer.colorize("Please enter the URL you want to crawl: ", Cyan));
-            String url = validate(reader.readLine(), "https://www.orf.at/", "(Default): No value has been entered. Default: 'https://www.orf.at/'");
+            System.out.println("Separate multiple domains with a comma (,), e.g. 'google.com, orf.at' or provide a single or e.g. 'google.com'");
+            System.out.print(Colorizer.colorize("Please enter the URL(s) you want to crawl: ", Cyan));
+            String[] urls = validate(reader.readLine(), "https://www.orf.at/", "(Default): No value has been entered. Default: 'https://www.orf.at/'").split(",");
+
 
             System.out.print(Colorizer.colorize("Please enter the maximum depth you want to crawl (max. 2):", Cyan));
             int maxDepth = Math.max(validate(reader.readLine(), 1, "(Default): No value has been entered. Default: 1"), 2);
@@ -54,7 +56,7 @@ public class Configuration {
             String language = validate(reader.readLine(), "en", "(Default): No value has been entered. Default: en");
 
 
-            return new Configuration(url, maxDepth, domains, language);
+            return new Configuration(urls, maxDepth, domains, language);
         } catch (IOException e) {
             System.out.println("Error while reading input. Please try again.");
             return requestConfiguration();
@@ -62,8 +64,8 @@ public class Configuration {
     }
 
 
-    public String getUrl () {
-        return url;
+    public String[] getUrls () {
+        return urls;
     }
 
     public int getMaxDepth () {

--- a/src/main/java/org/crawler/crawl/ConcurrencyHandler.java
+++ b/src/main/java/org/crawler/crawl/ConcurrencyHandler.java
@@ -1,0 +1,87 @@
+package org.crawler.crawl;
+
+import org.crawler.Console.Console;
+import org.crawler.config.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.crawler.Console.Color.Red;
+import static org.crawler.Console.Color.Yellow;
+
+public class ConcurrencyHandler {
+    private Configuration config;
+    private ExecutorService executorService;
+    private Collection<Callable<PageInfo>> callables = new ArrayList<>();
+
+    private List<Future<PageInfo>> threads = new ArrayList<>();
+
+    public ConcurrencyHandler (Configuration config) {
+        this.config = config;
+
+        init();
+        createThreads();
+    }
+
+    /**
+     * This method starts all threads and waits for them to finish.
+     * Note, that this method must not be called. It is called internally by getResults() if it has not been called.
+     */
+    public void start () {
+        if (!this.threads.isEmpty()) return;
+
+        Console.print(Yellow, "Starting threads...");
+        try {
+            this.threads = executorService.invokeAll(callables);
+        } catch (InterruptedException e) {
+            Console.print(Red, "Invoking Threads failed");
+        }
+    }
+
+    /**
+     * This method waits internally for all threads to finish and returns the results.
+     * @return A list of PageInfo's that holds the results of each Crawler
+     */
+    public List<PageInfo> getResults () {
+        if (threads.isEmpty()) start();
+
+        List<PageInfo> results = new ArrayList<>();
+
+        for (Future<PageInfo> future : threads) {
+            try {
+                results.add(future.get());
+            } catch (ExecutionException | InterruptedException e) {
+                Console.print(Red, "Getting Thread-Results did throw an Exception");
+            }
+        }
+
+
+        executorService.shutdown();
+        return results;
+    }
+
+    /**
+     * This method initializes the ConcurrencyHandler by clearing the callables and creating a new ExecutorService.
+     */
+    private void init () {
+        callables.clear();
+        executorService = Executors.newFixedThreadPool(config.getUrls().length);
+    }
+
+    /**
+     * This method creates a new Callable for each URL in the Configuration and adds it to the callables list.
+     */
+    private void createThreads () {
+        for (int i = 0; i < config.getUrls().length; i++) {
+            int finalI = i;
+            Callable<PageInfo> callable = () -> {
+                Crawler c1 = new Crawler(config);
+                return c1.crawl(config.getUrls()[finalI]);
+            };
+            callables.add(callable);
+        }
+    }
+
+}

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -23,8 +23,8 @@ public class Crawler {
         this.config = config;
     }
 
-    public PageInfo crawl () {
-        return getPage(config.getUrl(), 0, config.getMaxDepth(), config.getDomains());
+    public PageInfo crawl (String url) {
+        return getPage(url, 0, config.getMaxDepth(), config.getDomains());
     }
 
     private PageInfo getPage (String url, int currentDepth, int maxDepth, String[] allowedDomains) {


### PR DESCRIPTION
The following changes are made in this Pull request:
- modified `Configuration` class to request multiple urls
   When requesting the Configuration from the user, using the `Configuration`.`requestConfiguration` method, the user can now enter multiple urls. In doing so, the Configuration's url property has been renamed to urls and the type has been changed from String to String[] to store the Array of urls.

   At the same time, the `crawl` method inside the Crawler has been changed to take in a given url to crawl. since it can no longer use the getUrl method from the Configuration since it has been changed to getUrls, which returns an array of urls.
- created `ConcurrencyHandler` class
   This class is used to execute multiple Crawlers at the same time. When creating a new instance it takes in a Configuration instance. Based on the given configuration a new thread-pool is created and a callable instance for each crawl-job is created.

   When the `start` method of the ConcurrencyCrawler is executed it will run all the callable-jobs that were previously created. Note, the start method will also be called automatically, when calling the `getResult` method, when it has not been called.

   It also exposes a `getResults` method, which waits for each crawl-job to return its result. These results are then returned.
- removed unnecessary throws declarations
   Removed unnecessary `throws IOException` declarations inside of the `Printer` class.
- created `printReports` method in Printer
   The `Printer` class now also exposes a `printReports` method that creates a report for an array of PageInfos.
- applied `ConcurrencyHandler` in Main
   The main method of this project now uses the new ConcurrencyHandler to crawl multiple pages concurrently.