### PR TITLE
Refactor: Improved the Quality of the Codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ bin/
 ### Mac OS ###
 .DS_Store
 
-report.md
+*.md
+!README.md

--- a/src/main/java/org/crawler/Console/Colorizer.java
+++ b/src/main/java/org/crawler/Console/Colorizer.java
@@ -29,6 +29,8 @@ public class Colorizer {
      * @return the colorized message
      */
     public static String colorize (String message, Color color) {
+        if (!Console.colorizeLogs) return message;
+
         String colorCode = colorMap.get(color.name()).get(ColorType.regular);
         return colorCode + message + RESET;
     }
@@ -41,6 +43,8 @@ public class Colorizer {
      * @return the colorized message
      */
     public static String colorize (String message, Color color, ColorType type) {
+        if (!Console.colorizeLogs) return message;
+
         String colorCode = colorMap.get(color.name()).get(type);
         return colorCode + message + RESET;
     }

--- a/src/main/java/org/crawler/Console/Console.java
+++ b/src/main/java/org/crawler/Console/Console.java
@@ -15,7 +15,7 @@ public class Console {
         StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
 
         String name = stackTraceElements[traceOriginIndex].getClassName().split("\\.")[stackTraceElements[traceOriginIndex].getClassName().split("\\.").length - 1];
-        return format("[%s::l %s]", name, stackTraceElements[traceOriginIndex].getLineNumber());
+        return format("[%s]", name);
     }
 
     /**

--- a/src/main/java/org/crawler/Console/Console.java
+++ b/src/main/java/org/crawler/Console/Console.java
@@ -6,6 +6,8 @@ import static org.crawler.Console.ColorType.bright;
 import static org.crawler.Console.Colorizer.colorize;
 
 public class Console {
+    public static boolean colorizeLogs = true;
+
     /**
      * This method is used to get the caller's class name and line number.
      * @return A string containing the caller's class name and line number.
@@ -26,7 +28,7 @@ public class Console {
         String caller = getCallerInfo();
         String merge = String.join(" ", message);
 
-        System.out.println(caller + ": " + merge);
+        System.out.println(colorize(caller + ":", Yellow, bright) + " " + merge);
     }
 
     /**

--- a/src/main/java/org/crawler/Printer.java
+++ b/src/main/java/org/crawler/Printer.java
@@ -30,11 +30,10 @@ public class Printer {
         lines.add(String.format("input: <%s>", page.getUrl()));
         lines.add(String.format("language: <%s>", page.getLanguage()));
 
-        if (page.isEmpty()) lines.add("This page is empty.");
         if (page.hasFailed()) {
             lines.add("Error: " + page.getFailureReson());
             return lines;
-        }
+        } else if (page.isEmpty()) lines.add("This page is empty.");
 
         lines.addAll(formatPageHeadings(page));
         lines.addAll(createSubPagesReport(page));

--- a/src/main/java/org/crawler/Printer.java
+++ b/src/main/java/org/crawler/Printer.java
@@ -29,7 +29,12 @@ public class Printer {
 
         lines.add(String.format("input: <%s>", page.getUrl()));
         lines.add(String.format("language: <%s>", page.getLanguage()));
-        if (page.isBroken()) lines.add("Broken page!");
+
+        if (page.isEmpty()) lines.add("This page is empty.");
+        if (page.hasFailed()) {
+            lines.add("Error: " + page.getFailureReson());
+            return lines;
+        }
 
         lines.addAll(formatPageHeadings(page));
         lines.addAll(createSubPagesReport(page));

--- a/src/main/java/org/crawler/config/Configuration.java
+++ b/src/main/java/org/crawler/config/Configuration.java
@@ -34,7 +34,7 @@ public class Configuration {
         try {
             System.out.println(Colorizer.colorize("Welcome to the Crawler-Configuration-Tool!", Green, bold));
 
-            System.out.println("Separate multiple domains with a comma (,), e.g. 'google.com, orf.at' or provide a single or e.g. 'google.com'");
+            System.out.println("Separate multiple domains with a comma (,), e.g. 'https://www.discord.com/, https://www.orf.at/' or provide a single or e.g. 'https://www.orf.at/'");
             System.out.print(Colorizer.colorize("Please enter the URL(s) you want to crawl: ", Cyan));
             String[] urls = validate(reader.readLine(), "https://www.orf.at/", "(Default): No value has been entered. Default: 'https://www.orf.at/'").split(",");
 

--- a/src/main/java/org/crawler/config/Configuration.java
+++ b/src/main/java/org/crawler/config/Configuration.java
@@ -28,6 +28,13 @@ public class Configuration {
         this.targetLanguage = targetLanguage;
     }
 
+    public Configuration (String url, int maxDepth, String[] domains, String targetLanguage) {
+        this.urls = new String[]{url};
+        this.maxDepth = maxDepth;
+        this.domains = domains;
+        this.targetLanguage = targetLanguage;
+    }
+
     public static Configuration requestConfiguration () {
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
 

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -39,7 +39,7 @@ public class Crawler {
      * @implNote Would be private if it wasn't for testing purposes.
      */
     public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
-        PageInfo result = new PageInfo(url, "unknown", new Elements(), new ArrayList<>(), depth);
+        PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
         Document document = null;
         try {
             document = getDocument(url);

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.crawler.Console.Color.Red;
+
 
 public class Crawler {
     private Configuration config;
@@ -44,6 +46,8 @@ public class Crawler {
         try {
             document = getDocument(url);
         } catch (IOException e) {
+            Console.print(Red, "Document Retrieval for", url, "failed.");
+            
             //* In case one cannot connect to the requested URL
             result.setFailureReason(e.toString());
             return result;

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -9,7 +9,6 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.jsoup.select.NodeFilter;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,16 +23,14 @@ public class Crawler {
     }
 
     public PageInfo crawl (String url) {
+        Console.print("Crawler with id: " + Thread.currentThread().getId(), "is going to crawl", url, "\n");
         return getPage(url, 0, config.getMaxDepth(), config.getDomains());
     }
 
     private PageInfo getPage (String url, int currentDepth, int maxDepth, String[] allowedDomains) {
         if (currentDepth > maxDepth) return null;
-        System.out.println("Crawling-Depth: " + currentDepth);
         PageInfo page = retrievePageInfo(url, allowedDomains, currentDepth);
-
-        List<String> links_to_crawl = page.getPageLinks();
-        System.out.println("-> Page has " + links_to_crawl.size() + " sublinks...");
+        Console.print("[id: " + Thread.currentThread().getId() + "]:", page.getPageLinks().size() + "", "Sublinks found in (depth", (currentDepth) + ")", url);
 
         recursion(page, currentDepth, maxDepth, allowedDomains);
         return page;
@@ -49,9 +46,6 @@ public class Crawler {
         //* In case one cannot connect to the requested URL
         if (document == null) return result;
 
-        System.out.println();
-        System.out.println("Crawling: " + document.title());
-
         result.setLanguage(getSourceLanguage(document));
         result.setHeadings(document.select("h1, h2, h3, h4, h5, h6"));
         result.setPageLinks(removeLinkLoops(url, getFilteredPageLinks(document, domains)));
@@ -61,8 +55,6 @@ public class Crawler {
 
     private void recursion (PageInfo originPage, int currentDepth, int maxDepth, String[] allowedDomains) {
         List<String> links_to_crawl = originPage.getPageLinks();
-        System.out.println("-> Page has " + links_to_crawl.size() + " sublinks...");
-
 
         ArrayList<PageInfo> results = new ArrayList<>();
         for (String link : links_to_crawl) {
@@ -82,10 +74,8 @@ public class Crawler {
         try {
             Connection connection = Jsoup.connect(url);
             return connection.get();
-        } catch (IOException e) {
-            Console.print(Red, "Retrieval was not successful for", url, "due to an IOException.");
-        } catch (Exception ignored) {
-            Console.print(Red, "Retrieving document from", url, "failed.");
+        } catch (Exception e) {
+            Console.print(Red, "Document Retrieval for", url, "failed.");
         }
         return null;
     }

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -28,7 +28,7 @@ public class Crawler {
     }
 
     private PageInfo getPage (String url, int currentDepth, int maxDepth, String[] allowedDomains) {
-        if (currentDepth >= maxDepth) return null;
+        if (currentDepth > maxDepth) return null;
         System.out.println("Crawling-Depth: " + currentDepth);
         PageInfo page = retrievePageInfo(url, allowedDomains, currentDepth);
 

--- a/src/main/java/org/crawler/crawl/Crawler.java
+++ b/src/main/java/org/crawler/crawl/Crawler.java
@@ -9,10 +9,9 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.jsoup.select.NodeFilter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.crawler.Console.Color.Red;
 
 
 public class Crawler {
@@ -40,11 +39,15 @@ public class Crawler {
      * @implNote Would be private if it wasn't for testing purposes.
      */
     public PageInfo retrievePageInfo (String url, String[] domains, int depth) {
-        PageInfo result = new PageInfo(url, "", new Elements(), new ArrayList<>(), depth);
-        Document document = getDocument(url);
-
-        //* In case one cannot connect to the requested URL
-        if (document == null) return result;
+        PageInfo result = new PageInfo(url, "unknown", new Elements(), new ArrayList<>(), depth);
+        Document document = null;
+        try {
+            document = getDocument(url);
+        } catch (IOException e) {
+            //* In case one cannot connect to the requested URL
+            result.setFailureReason(e.toString());
+            return result;
+        }
 
         result.setLanguage(getSourceLanguage(document));
         result.setHeadings(document.select("h1, h2, h3, h4, h5, h6"));
@@ -70,14 +73,9 @@ public class Crawler {
     /**
      * @implNote Would be private if it wasn't for testing purposes.
      */
-    public Document getDocument (String url) {
-        try {
-            Connection connection = Jsoup.connect(url);
-            return connection.get();
-        } catch (Exception e) {
-            Console.print(Red, "Document Retrieval for", url, "failed.");
-        }
-        return null;
+    public Document getDocument (String url) throws IOException {
+        Connection connection = Jsoup.connect(url);
+        return connection.get();
     }
 
 

--- a/src/main/java/org/crawler/crawl/PageInfo.java
+++ b/src/main/java/org/crawler/crawl/PageInfo.java
@@ -40,7 +40,7 @@ public class PageInfo {
     }
 
     public String getLanguage () {
-        return language;
+        return language.isEmpty() ? "unknown" : language;
     }
 
     public void setLanguage (String language) {

--- a/src/main/java/org/crawler/crawl/PageInfo.java
+++ b/src/main/java/org/crawler/crawl/PageInfo.java
@@ -13,7 +13,6 @@ public class PageInfo {
     private List<String> pageLinks;
     private ArrayList<PageInfo> subPagesInfo = new ArrayList<>();
     private int depth;
-    private boolean failed = false;
     private String failureReson;
 
     public PageInfo (String url, String language, Elements headings, List<String> pageLinks, int depth) {
@@ -68,8 +67,7 @@ public class PageInfo {
         return depth;
     }
 
-    public void setFailed (String failureReson) {
-        this.failed = true;
+    public void setFailureReason (String failureReson) {
         this.failureReson = failureReson;
     }
 
@@ -78,7 +76,7 @@ public class PageInfo {
     }
 
     public boolean hasFailed () {
-        return this.failed;
+        return this.failureReson != null && !this.failureReson.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/crawler/crawl/PageInfo.java
+++ b/src/main/java/org/crawler/crawl/PageInfo.java
@@ -24,8 +24,8 @@ public class PageInfo {
         this.depth = depth;
     }
 
-    public boolean isBroken () {
-        return language.isEmpty();
+    public boolean isEmpty () {
+        return language.isEmpty() && headings.isEmpty();
     }
 
     public List<String> getPageLinks () {

--- a/src/main/java/org/crawler/crawl/PageInfo.java
+++ b/src/main/java/org/crawler/crawl/PageInfo.java
@@ -13,6 +13,8 @@ public class PageInfo {
     private List<String> pageLinks;
     private ArrayList<PageInfo> subPagesInfo = new ArrayList<>();
     private int depth;
+    private boolean failed = false;
+    private String failureReson;
 
     public PageInfo (String url, String language, Elements headings, List<String> pageLinks, int depth) {
         this.url = url;
@@ -64,6 +66,19 @@ public class PageInfo {
 
     public int getDepth () {
         return depth;
+    }
+
+    public void setFailed (String failureReson) {
+        this.failed = true;
+        this.failureReson = failureReson;
+    }
+
+    public String getFailureReson () {
+        return this.failureReson;
+    }
+
+    public boolean hasFailed () {
+        return this.failed;
     }
 
     @Override

--- a/src/test/java/PrinterTests.java
+++ b/src/test/java/PrinterTests.java
@@ -23,7 +23,7 @@ public class PrinterTests {
 
 
     @BeforeEach
-    public void setUp() {
+    public void setUp () {
         when(mockedElement.tagName()).thenReturn("h2");
         when(mockedElement.text()).thenReturn("I am a sample heading.");
 
@@ -33,7 +33,7 @@ public class PrinterTests {
 
         when(mockedValidPageInfo.getPageLinks()).thenReturn(pageLinks);
         when(mockedValidPageInfo.getSubPagesInfo()).thenReturn(new ArrayList<>());
-        when(mockedValidPageInfo.isBroken()).thenReturn(false);
+        when(mockedValidPageInfo.isEmpty()).thenReturn(false);
         when(mockedValidPageInfo.getUrl()).thenReturn("http://link.at");
         when(mockedValidPageInfo.getLanguage()).thenReturn("de");
 
@@ -47,7 +47,7 @@ public class PrinterTests {
     }
 
     @Test
-    public void testCreateReport_Depth_0() throws IOException {
+    public void testCreateReport_Depth_0 () throws IOException {
         when(mockedValidPageInfo.getDepth()).thenReturn(0);
 
         List<String> report = Printer.createReport(mockedValidPageInfo);
@@ -58,7 +58,7 @@ public class PrinterTests {
     }
 
     @Test
-    public void testCreateReport_Depth_1() throws IOException {
+    public void testCreateReport_Depth_1 () throws IOException {
         when(mockedValidPageInfo.getDepth()).thenReturn(1);
 
         List<String> report = Printer.createReport(mockedValidPageInfo);
@@ -69,8 +69,8 @@ public class PrinterTests {
     }
 
     @Test
-    public void testCreateReport_InvalidPageInfo() throws IOException {
-        when(mockedInvalidPageInfo.isBroken()).thenReturn(true);
+    public void testCreateReport_InvalidPageInfo () throws IOException {
+        when(mockedInvalidPageInfo.isEmpty()).thenReturn(true);
         when(mockedInvalidPageInfo.getLanguage()).thenReturn("");
 
 

--- a/src/test/java/crawl/CrawlerTests.java
+++ b/src/test/java/crawl/CrawlerTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.mockito.Mockito.mock;
@@ -34,7 +35,7 @@ class CrawlerTests {
     public void setup () {
         crawler = new Crawler(config);
 
-        
+
         Element[] mockedPageHeadings = new Element[]{mockedHeading, mockedHeading, mockedHeading};
         Elements el = new Elements();
 
@@ -62,7 +63,7 @@ class CrawlerTests {
 
     @ParameterizedTest
     @ValueSource(strings = {"https://orf.at/", "https://www.derstandard.at/", "invalid.url.at"})
-    public void test_getDocument (String url) {
+    public void test_getDocument (String url) throws IOException {
         Document document = crawler.getDocument(url);
 
         if (url.startsWith("https://") || url.startsWith("http://")) Assertions.assertNotNull(document);


### PR DESCRIPTION
The following changes were made in this Pull request:
- fixed crawling-depth condition in the `Crawler`
   Previously the Crawler did not crawl pages that had a depth equal to the maxDepth. In other words, it left out one depth-layer. Therefore, the condition has been modified so that the Crawler actually crawls the requested depth-level.
- reworked the logs inside of the `Crawler`
   Replaced all the System.out logs with the `Console`.`print` method. This way it is clear where the logs come from. 
   Additionally most log-messages were either replaced with more meaningful log-messages or removed.
- removed the line-number in the print-statements of the `Console` class
   When printing logs using the `Console`.`print` method the line-number is no longer printed. The reason for this is that the line-number is not really meaningful.
- added `colorizeLogs` boolean to `Console` class
   With the help of this static `colorizeLogs` variable it is possible to specific whether the logs printed using the Console's methods shall be colorized. By default, the logs are colorized.
- updated url example log-statement in the `requestConfiguration` method
   Updated the examples that are provided for valid urls in the `requestConfiguration` method to include "https://".
- modified the `PageInfo` class
   added two a new private property called `failureReason`. This string holds a potential exception as a string, when the page-retrievel failed.
   In doing so the `PageInfo` class received three additional methods: 
   - getter and setter for the `failureReason`
   - `hasFailed` method that returns true when the failureReason is either null or empty

  Additionally, the `isBroken` method was renamed to `isEmpty` and also checks whether no headings were found to indicate that the page is truly empty. 

- updated the getter of the language property in the `PageInfo` class
   Changed the language-value that is provided to the constructor of a new PageInfo object in the Crawler from "unknown" back to an empty string (""). The reason for this is that, this way the isEmpty check simply checks whether the string is empty to determinate whether a language has been found or not.

   However, to make it clear that no language was found when the value of the language property is empty, the getter for the language-field has been modified. When the language-value is equal to an empty string the getter returns "unknown". 
   This way it is clear when a language was or was not found in a page inside the report.
- updated error-handling in the `Crawler`
   In case the document-retrieval for a page fails due to an IOException the exception is stored in the PageInfo as the `failureReason`.
- added secondary constructor to the `Configuration` class
   Added a secondary constructor that takes in a single url of type string that is then internally converted to an array with a length of 1.
- updated `.gitignore` to ignore all markdown files expect the ReadMe
   Now all markdown files except the ReadMe are ignored to ignore all future reports that may be stored under a different name.
