### PR TITLE
Feat: Created JsoupAdapter that wraps the Jsoup-Dependency

### DIFF
--- a/src/main/java/org/crawler/adapters/JsoupAdapter.java
+++ b/src/main/java/org/crawler/adapters/JsoupAdapter.java
@@ -1,0 +1,33 @@
+package org.crawler.adapters;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JsoupAdapter {
+    public static Document fetchDocument (String url) throws IOException {
+        Connection connection = Jsoup.connect(url);
+        return connection.get();
+    }
+
+    public static String getLanguage (Document document) {
+        return document.select("html").attr("lang");
+    }
+
+    public static Elements getHeadings (Document document) {
+        return document.select("h1, h2, h3, h4, h5, h6");
+    }
+
+    public static List<String> getLinks (Document document) {
+        Elements anchors = document.select("a");
+        List<String> links = new ArrayList<>();
+
+        anchors.forEach(element -> links.add(element.attr("href")));
+        return links;
+    }
+}


### PR DESCRIPTION
#### The following changes were made in this Pull request:

- created simple adapter for `Jsoup` dependency
  This adapter exposes helper-function that centralize the use of the `Jsoup` dependency. In other words, if the dependency for the document-retrieval would change, this adapter would have to be changed, but the rest of the code would not change too much. In doing so the codebase is a bit more independent from the dependencies.